### PR TITLE
添加控制内容宽度及隐藏底部栏的功能

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
             "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.27.1",
@@ -1534,6 +1535,7 @@
             "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "6.21.0",
                 "@typescript-eslint/types": "6.21.0",
@@ -1925,6 +1927,7 @@
             "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -2277,6 +2280,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001716",
                 "electron-to-chromium": "^1.5.149",
@@ -3021,6 +3025,7 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -4124,6 +4129,7 @@
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -5465,6 +5471,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.8",
                 "picocolors": "^1.1.1",
@@ -5922,6 +5929,7 @@
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -6542,6 +6550,7 @@
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -6663,6 +6672,7 @@
             "integrity": "sha512-CNqKBRMQjwcmKR0idID5va1qlhrqVUKpovi+Ec79ksW8ux7iS1+A6VqzfZXgVYCFRKl7XL5ap3ZoMpwBJxcg0w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.6",
@@ -6711,6 +6721,7 @@
             "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -24,6 +24,7 @@ let settings: Settings;
 let isInitialized = false;
 const CONTENT_WIDTH_STYLE_ID = "wre-content-max-width-style";
 const BOTTOM_BAR_PADDING_STYLE_ID = "wre-bottom-bar-padding-style";
+const BOTTOM_BAR_STYLE_ID = "wre-hide-bottom-bar-style";
 
 /**
  * 初始化插件
@@ -71,6 +72,9 @@ async function init(): Promise<void> {
 
     // 先应用页面内容最大宽度覆盖（无论是否找到文章容器）
     applyContentMaxWidth(settings.contentMaxWidth);
+
+    // 应用底部栏隐藏设置
+    applyHideBottomBar(settings.hideBottomBar);
 
     // 查找文章容器
     const articleContainer = findArticleContainer();
@@ -208,6 +212,11 @@ function handleSettingsChange(newSettings: Settings): void {
     applyContentMaxWidth(newSettings.contentMaxWidth);
   }
 
+  // 单独处理底部栏隐藏：无需完全重建
+  if (newSettings.hideBottomBar !== settings.hideBottomBar) {
+    applyHideBottomBar(newSettings.hideBottomBar);
+  }
+
   // 更新设置
   settings = newSettings;
 }
@@ -273,6 +282,24 @@ function applyContentMaxWidth(width?: number): void {
     document.documentElement.appendChild(paddingStyle);
   } catch (e) {
     console.warn("应用内容最大宽度失败", e);
+  }
+}
+
+// 隐藏/显示底部栏
+function applyHideBottomBar(hide?: boolean): void {
+  try {
+    // 清理旧样式
+    const prev = document.getElementById(BOTTOM_BAR_STYLE_ID);
+    if (prev && prev.parentNode) prev.parentNode.removeChild(prev);
+
+    if (!hide) return;
+
+    const style = document.createElement("style");
+    style.id = BOTTOM_BAR_STYLE_ID;
+    style.textContent = "#js_article_bottom_bar{display: none !important;}";
+    document.documentElement.appendChild(style);
+  } catch (e) {
+    console.warn("应用底部栏隐藏失败", e);
   }
 }
 

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -504,12 +504,38 @@
       </div>
       <div class="range-wrapper">
         <div class="range-track"></div>
-        <div class="range-progress"></div>
+        <div class="range-progress" id="rangeProgress"></div>
         <input type="range" id="tocWidthRange" min="200" max="400" step="10" value="280" title="拖动调整目录宽度" aria-label="拖动调整目录宽度">
       </div>
 
       <div class="buttons">
         <button class="secondary" id="resetButton">恢复默认</button>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-title">
+        <span class="icon">
+          <svg class="svg-icon" viewBox="0 0 24 24">
+            <path d="M4 6h16v2H4V6zm0 5h16v2H4v-2zm0 5h16v2H4v-2z"/>
+          </svg>
+        </span>
+        页面内容宽度
+      </div>
+      <div class="card-subtitle">调整公众号文章内容区域的最大宽度（覆盖 677px 默认值）</div>
+
+      <label for="contentMaxWidth">内容最大宽度</label>
+      <div class="flex-between">
+        <input type="number" id="contentMaxWidth" min="480" max="2560" value="677" aria-label="内容最大宽度数值" title="内容最大宽度数值">
+        <span>px</span>
+      </div>
+      <div class="range-wrapper">
+        <div class="range-track"></div>
+        <div class="range-progress" id="contentWidthProgress"></div>
+        <input type="range" id="contentMaxWidthRange" min="480" max="2560" step="10" value="677" title="拖动调整内容最大宽度" aria-label="拖动调整内容最大宽度">
+      </div>
+      <div class="buttons">
+        <button class="secondary" id="resetContentWidthButton">恢复默认</button>
       </div>
     </div>
 

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -543,6 +543,21 @@
       <div class="card-title">
         <span class="icon">
           <svg class="svg-icon" viewBox="0 0 24 24">
+            <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+          </svg>
+        </span>
+        是否隐藏底部栏
+      </div>
+      <div class="card-subtitle">隐藏公众号文章底部的操作栏</div>
+      <div class="buttons">
+        <button class="secondary" id="toggleBottomBarButton">隐藏底部栏</button>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-title">
+        <span class="icon">
+          <svg class="svg-icon" viewBox="0 0 24 24">
             <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"/>
           </svg>
         </span>

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -12,12 +12,27 @@ const tocWidthRange = document.getElementById(
 const rangeProgress = document.getElementById("rangeProgress") as HTMLElement;
 const resetButton = document.getElementById("resetButton") as HTMLButtonElement;
 
+// 新增：页面内容宽度相关元素
+const contentMaxWidthInput = document.getElementById(
+  "contentMaxWidth"
+) as HTMLInputElement;
+const contentMaxWidthRange = document.getElementById(
+  "contentMaxWidthRange"
+) as HTMLInputElement;
+const contentWidthProgress = document.getElementById(
+  "contentWidthProgress"
+) as HTMLElement;
+const resetContentWidthButton = document.getElementById(
+  "resetContentWidthButton"
+) as HTMLButtonElement | null;
+
 // 默认设置
 const defaultSettings: Settings = {
   tocWidth: 280,
   minLevel: 1,
   maxLevel: 6,
   isEnabled: true,
+  contentMaxWidth: 677,
 };
 
 // 上次触发时间
@@ -25,6 +40,9 @@ let lastTocWidthUpdate = 0;
 // 宽度更新状态
 let pendingWidthUpdate: number | null = null;
 let updateTimeoutId: number | null = null;
+// 新增：内容宽度节流状态
+let pendingContentWidthUpdate: number | null = null;
+let contentUpdateTimeoutId: number | null = null;
 
 // 初始化
 async function init() {
@@ -53,6 +71,13 @@ function updateForm(settings: Settings) {
   tocWidthInput.value = settings.tocWidth.toString();
   tocWidthRange.value = settings.tocWidth.toString();
   updateRangeProgressUI();
+  // 新增：页面内容宽度
+  if (contentMaxWidthInput && contentMaxWidthRange) {
+    const width = settings.contentMaxWidth ?? defaultSettings.contentMaxWidth!;
+    contentMaxWidthInput.value = width.toString();
+    contentMaxWidthRange.value = width.toString();
+    updateContentWidthProgressUI();
+  }
 }
 
 // 获取当前设置
@@ -145,6 +170,42 @@ function setupEventListeners() {
     await updateTocWidth(defaultSettings.tocWidth);
     showMessage("已恢复默认宽度");
   });
+  // 新增：内容宽度输入框
+  contentMaxWidthInput?.addEventListener("input", async () => {
+    const width = parseInt(contentMaxWidthInput.value, 10);
+    if (width >= 480 && width <= 1400) {
+      if (contentMaxWidthRange) contentMaxWidthRange.value = width.toString();
+      updateContentWidthProgressUI();
+      await updateContentMaxWidth(width);
+    }
+  });
+  // 新增：内容宽度滑块
+  contentMaxWidthRange?.addEventListener("input", () => {
+    if (!contentMaxWidthRange || !contentMaxWidthInput) return;
+    const width = parseInt(contentMaxWidthRange.value, 10);
+    contentMaxWidthInput.value = width.toString();
+    updateContentWidthProgressUI();
+    throttledUpdateContentMaxWidth(width);
+  });
+  contentMaxWidthRange?.addEventListener("change", async () => {
+    if (!contentMaxWidthRange) return;
+    const width = parseInt(contentMaxWidthRange.value, 10);
+    if (pendingContentWidthUpdate !== null) {
+      await updateContentMaxWidth(width);
+      pendingContentWidthUpdate = null;
+    }
+  });
+
+  // 新增：恢复默认内容宽度
+  resetContentWidthButton?.addEventListener("click", async () => {
+    if (!contentMaxWidthInput || !contentMaxWidthRange) return;
+    const width = defaultSettings.contentMaxWidth!;
+    contentMaxWidthInput.value = width.toString();
+    contentMaxWidthRange.value = width.toString();
+    updateContentWidthProgressUI();
+    await updateContentMaxWidth(width);
+    showMessage("已恢复默认内容宽度");
+  });
 }
 
 // 处理 logo 图片路径
@@ -199,6 +260,15 @@ function handleRangeInput(this: HTMLInputElement) {
     console.error("rangeProgress element not found!");
   }
 }
+// 新增：更新内容宽度进度条 UI
+function updateContentWidthProgressUI() {
+  if (!contentMaxWidthRange || !contentWidthProgress) return;
+  const min = parseInt(contentMaxWidthRange.min);
+  const max = parseInt(contentMaxWidthRange.max);
+  const value = parseInt(contentMaxWidthRange.value);
+  const percentage = ((value - min) / (max - min)) * 100;
+  contentWidthProgress.style.setProperty("width", `${percentage}%`, "important");
+}
 
 // 节流函数，限制updateTocWidth的调用频率
 function throttledUpdateTocWidth(width: number) {
@@ -242,6 +312,34 @@ async function updateTocWidth(width: number) {
     await notifySettingsChanged(settings);
   } catch (error) {
     console.error("更新宽度失败:", error);
+  }
+}
+
+// 新增：节流更新内容最大宽度
+function throttledUpdateContentMaxWidth(width: number) {
+  pendingContentWidthUpdate = width;
+  const throttleDelay = 500;
+  if (contentUpdateTimeoutId !== null) {
+    window.clearTimeout(contentUpdateTimeoutId);
+    contentUpdateTimeoutId = null;
+  }
+  contentUpdateTimeoutId = window.setTimeout(async () => {
+    if (pendingContentWidthUpdate !== null) {
+      await updateContentMaxWidth(pendingContentWidthUpdate);
+      pendingContentWidthUpdate = null;
+    }
+  }, throttleDelay);
+}
+
+// 新增：更新内容最大宽度
+async function updateContentMaxWidth(width: number) {
+  try {
+    const settings = await getSettings();
+    settings.contentMaxWidth = width;
+    await saveSettings(settings);
+    await notifySettingsChanged(settings);
+  } catch (error) {
+    console.error("更新内容最大宽度失败:", error);
   }
 }
 

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -25,6 +25,9 @@ const contentWidthProgress = document.getElementById(
 const resetContentWidthButton = document.getElementById(
   "resetContentWidthButton"
 ) as HTMLButtonElement | null;
+const toggleBottomBarButton = document.getElementById(
+  "toggleBottomBarButton"
+) as HTMLButtonElement | null;
 
 // 默认设置
 const defaultSettings: Settings = {
@@ -33,6 +36,7 @@ const defaultSettings: Settings = {
   maxLevel: 6,
   isEnabled: true,
   contentMaxWidth: 677,
+  hideBottomBar: false,
 };
 
 // 上次触发时间
@@ -78,6 +82,8 @@ function updateForm(settings: Settings) {
     contentMaxWidthRange.value = width.toString();
     updateContentWidthProgressUI();
   }
+  // 新增：底部栏隐藏状态
+  updateBottomBarButton(settings.hideBottomBar ?? false);
 }
 
 // 获取当前设置
@@ -205,6 +211,15 @@ function setupEventListeners() {
     updateContentWidthProgressUI();
     await updateContentMaxWidth(width);
     showMessage("已恢复默认内容宽度");
+  });
+
+  // 新增：切换底部栏显示/隐藏
+  toggleBottomBarButton?.addEventListener("click", async () => {
+    const settings = await getSettings();
+    const newValue = !(settings.hideBottomBar ?? false);
+    await updateHideBottomBar(newValue);
+    updateBottomBarButton(newValue);
+    showMessage(newValue ? "已隐藏底部栏" : "已显示底部栏");
   });
 }
 
@@ -340,6 +355,31 @@ async function updateContentMaxWidth(width: number) {
     await notifySettingsChanged(settings);
   } catch (error) {
     console.error("更新内容最大宽度失败:", error);
+  }
+}
+
+// 新增：更新底部栏隐藏状态
+async function updateHideBottomBar(hide: boolean) {
+  try {
+    const settings = await getSettings();
+    settings.hideBottomBar = hide;
+    await saveSettings(settings);
+    await notifySettingsChanged(settings);
+  } catch (error) {
+    console.error("更新底部栏隐藏状态失败:", error);
+  }
+}
+
+// 新增：更新底部栏按钮文本和样式
+function updateBottomBarButton(hide: boolean) {
+  if (!toggleBottomBarButton) return;
+  toggleBottomBarButton.textContent = hide ? "显示底部栏" : "隐藏底部栏";
+  if (hide) {
+    toggleBottomBarButton.classList.remove("secondary");
+    toggleBottomBarButton.classList.add("primary");
+  } else {
+    toggleBottomBarButton.classList.remove("primary");
+    toggleBottomBarButton.classList.add("secondary");
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ export interface Settings {
   maxLevel: number; // 识别的最大标题级别
   isEnabled: boolean; // 插件是否启用
   contentMaxWidth?: number; // 文章容器最大宽度（px）
+  hideBottomBar?: boolean; // 是否隐藏底部栏
 }
 
 // 脚本泄露报告

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,6 +18,7 @@ export interface Settings {
   minLevel: number; // 识别的最小标题级别
   maxLevel: number; // 识别的最大标题级别
   isEnabled: boolean; // 插件是否启用
+  contentMaxWidth?: number; // 文章容器最大宽度（px）
 }
 
 // 脚本泄露报告

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -18,6 +18,7 @@ export function getSettings(): Promise<Settings> {
         minLevel: 1,
         maxLevel: 6,
         isEnabled: true,
+        contentMaxWidth: 677,
       };
 
       resolve(data.settings || defaultSettings);

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -19,6 +19,7 @@ export function getSettings(): Promise<Settings> {
         maxLevel: 6,
         isEnabled: true,
         contentMaxWidth: 677,
+        hideBottomBar: false,
       };
 
       resolve(data.settings || defaultSettings);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 
-module.exports = {
+module.exports = (env, argv) => ({
   entry: {
     popup: "./src/popup/index.ts",
     content: "./src/content/index.ts",
@@ -13,6 +13,8 @@ module.exports = {
     path: path.resolve(__dirname, "dist"),
     clean: true,
   },
+  // 避免使用 eval 类 SourceMap，满足 MV3 的 CSP 要求
+  devtool: argv && argv.mode === "development" ? "inline-source-map" : false,
   module: {
     rules: [
       {
@@ -48,4 +50,4 @@ module.exports = {
       chunks: "async",
     },
   },
-};
+});


### PR DESCRIPTION
所作修改：
1. 微信公众号文章在电脑上浏览时设置的内容宽度过小，这里添加了可以修改内容宽度的功能
2. 公众号文档底部有一个作者信息、点赞分享栏，使用浏览器看时其实没有什么作用，作者信息可以通过点击文章顶部的作者名弹出，因此添加了一个开关，可以用于隐藏这个底部栏
3. 在我电脑上进行调试时会因为MV3 CSP的限制，导致无法加载dist的包，这里对config.js进行了部分修改